### PR TITLE
fix(metadata): update locale from "en_US" to "ru-RU"

### DIFF
--- a/sanity/lib/metadata.ts
+++ b/sanity/lib/metadata.ts
@@ -22,7 +22,7 @@ export function generatePageMetadata({
           height: page?.ogImage?.asset?.metadata?.dimensions?.height || 630,
         },
       ],
-      locale: "en_US",
+      locale: "ru-RU",
       type: "website",
     },
     robots: !isProduction


### PR DESCRIPTION
The locale in the page metadata was updated to "ru-RU" to better align with the target audience or language preferences of the application. This change ensures that the metadata accurately reflects the intended language setting.