### PR TITLE
fix(PhoneInput): change input type from tel to number for numeric input

### DIFF
--- a/components/shared/forms/PhoneInput.tsx
+++ b/components/shared/forms/PhoneInput.tsx
@@ -47,7 +47,8 @@ const PhoneInput: React.FC<PhoneInputProps> = ({
                                 ref={inputRef}
                                 placeholder={placeholder}
                                 className={className}
-                                type="tel"
+                                type="number"
+                                inputMode="numeric"
                                 // Обработчик для синхронизации значения с react-hook-form
                                 onChange={(e) => {
                                     field.onChange(e.target.value);


### PR DESCRIPTION
The input type was changed from 'tel' to 'number' with 'inputMode=numeric' to better handle numeric-only phone number input and improve mobile keyboard behavior. This provides a more appropriate input experience for phone numbers which are purely numeric.