### PR TITLE
refactor(RegionSelect): remove unused region options

### DIFF
--- a/components/shared/forms/RegionSelect.tsx
+++ b/components/shared/forms/RegionSelect.tsx
@@ -23,8 +23,6 @@ const RegionSelect: React.FC<RegionSelectProps> = ({
     regions = [
         { value: "Москва", label: "Москва" },
         { value: "Московская область", label: "Московская область" },
-        { value: "Санкт-Петербург", label: "Санкт-Петербург" },
-        { value: "Другой", label: "Другой регион" },
     ],
 }) => {
     return (


### PR DESCRIPTION
Remove "Санкт-Петербург" and "Другой регион" options from the default regions list as they are currently unused in the application. This simplifies the default configuration.