### PR TITLE
style(carousel): add object-contain class to AvatarImage

### DIFF
--- a/components/blocks/carousel/carousel-2.tsx
+++ b/components/blocks/carousel/carousel-2.tsx
@@ -46,6 +46,7 @@ export default function Carousel2({
                             <AvatarImage
                               src={urlFor(item.image).url()}
                               alt={item.name ?? ""}
+                              className="object-contain object-top"
                             />
                           )}
                           <AvatarFallback>


### PR DESCRIPTION
The AvatarImage in the carousel component now uses object-contain to ensure proper image scaling while maintaining aspect ratio. The object-top class is also added to align the image to the top of its container.