### PR TITLE
feat(header): pass social links to mobile nav component

### DIFF
--- a/components/layout/header/index.tsx
+++ b/components/layout/header/index.tsx
@@ -28,7 +28,7 @@ export default async function Header() {
           <SocialsList className="hidden xl:flex mr-4" items={siteSettings?.siteContactInfo?.socialLinks}/>
           <ModeToggle />
           <div className="xl:hidden">
-            <MobileNav navItems={NAV_ITEMS} />
+            <MobileNav navItems={NAV_ITEMS} socials={siteSettings?.siteContactInfo?.socialLinks} />
           </div>
         </div>
       </div>

--- a/components/layout/header/mobile-nav.tsx
+++ b/components/layout/header/mobile-nav.tsx
@@ -14,8 +14,9 @@ import { LogoMobile } from "@/components/ui/logo";
 import { useState } from "react";
 import { AlignRight } from "lucide-react";
 import { SocialsList } from "@/components/shared/socials";
+import { SocialsListProps } from "@/components/shared/socials/SocialsList";
 
-export default function MobileNav({ navItems }: { navItems: NavItem[] }) {
+export default function MobileNav({ navItems, socials }: { navItems: NavItem[], socials: SocialsListProps["items"] }) {
   const [open, setOpen] = useState(false);
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -62,7 +63,7 @@ export default function MobileNav({ navItems }: { navItems: NavItem[] }) {
                 Регистрация
               </Link>
             </Button>
-            <SocialsList />
+            <SocialsList items={socials} />
           </div>
         </div>
       </SheetContent>


### PR DESCRIPTION
The mobile navigation component now receives social links as props to display them consistently with the desktop version. This ensures uniform social media presence across both mobile and desktop views.