### PR TITLE
docs(layout): update footer link text from agreement to public offer

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -69,7 +69,7 @@ export default async function Footer() {
                   href={"/agreement"}
                   className="transition-colors"
                 >
-                  Пользовательское соглашение
+                  Публичная оферта
                 </Link>
               </li>
             </ul>


### PR DESCRIPTION
The link text was changed to better reflect the legal document it points to, which is a public offer rather than a user agreement.