### PR TITLE
feat(footer): add public offer link to footer navigation

### DIFF
--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -75,6 +75,14 @@ export default async function Footer() {
               </li>
               <li>
                 <Link
+                  href={"/publichnaya-oferta"}
+                  className="transition-colors"
+                >
+                  Публичная оферта
+                </Link>
+              </li>
+              <li>
+                <Link
                   href={"/dostavka-i-oplata"}
                   className="transition-colors"
                 >


### PR DESCRIPTION
Add a new navigation link to the public offer page in the footer section to improve site navigation and legal compliance.