### PR TITLE
fix: remove hardcoded fallback token for sanity API

### DIFF
--- a/sanity/lib/token.ts
+++ b/sanity/lib/token.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-export const token = process.env.SANITY_API_READ_TOKEN || 'skyTiKknAxLSgUB2xmdrCSjqvwsqUVVztGm4V8siYVYFpkna6y16o8okvI9Yfy6pgimRq3E3AZyfuFufGSnWMZY0XDjMcC45LjMi0nCtBALmidsKLQkC1fVlOvMzYA1AhHThq3Yho3Q3eRfu5GaeSLFQyts4XFCZcCHeyf0nu6rtt1k96gut';
+export const token = process.env.SANITY_API_READ_TOKEN;
 
 if (!token) {
   throw new Error("Missing SANITY_API_READ_TOKEN");


### PR DESCRIPTION
Using a hardcoded token is a security risk. The application should fail explicitly if the environment variable is not set.