### PR TITLE
feat: enable server actions with allowed origins configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
+  experimental: {
+    serverActions: {
+      allowedOrigins: ['bouquet4event.ru', '127.0.0.1:3000', 'localhost:3000'],
+    },
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
Add experimental serverActions configuration to specify allowed origins for security purposes. This allows the application to restrict server actions to specific domains including local development environments.