### PR TITLE
Set default href for CTAButton and CallBackDialog

### DIFF
--- a/app/(main)/products/[slug]/page.tsx
+++ b/app/(main)/products/[slug]/page.tsx
@@ -110,7 +110,7 @@ export default async function ProductPage({ params }: { params: Promise<Props> }
                             <p className="text-gray-600 mb-6">Наш менеджер свяжется с вами в ближайшее время</p>
                             <div className="flex flex-col md:flex-row gap-4">
                                 <CTAButton title="Оставить заявку" href="" customGoal="zakazbuket" />
-                                <CallBackDialog />
+                                <CallBackDialog href="#" />
                             </div>
                         </div>
                     </div>

--- a/components/shared/buttons/CTAButton.tsx
+++ b/components/shared/buttons/CTAButton.tsx
@@ -23,7 +23,7 @@ export function CTAButton({ title, href, buttonVariant = "default", target, clas
             className={`w-full md:w-auto md:min-w-40 group ${className || ''}`}
         >
             <Link
-                href={href}
+                href={href || '#'}
                 target={target ? "_blank" : undefined}
                 rel={target ? "noopener" : undefined}
             >

--- a/components/shared/dialog/CallBackDialog.tsx
+++ b/components/shared/dialog/CallBackDialog.tsx
@@ -5,7 +5,7 @@ import { CallBackForm } from '../forms'
 import { Button } from '@/components/ui/button'
 import {CTAButtonProps} from "@/components/shared/buttons/CTAButton";
 
-export default function CallBackDialog({ title, href, buttonVariant = "default", target, className, customGoal='' }: CTAButtonProps) {
+export default function CallBackDialog({ title, href='#', buttonVariant = "default", target, className, customGoal='' }: CTAButtonProps) {
     return (
         <Dialog>
             <DialogTrigger


### PR DESCRIPTION
Updated CTAButton and CallBackDialog components to use '#' as the default href when none is provided. Also updated usage in ProductPage to explicitly pass href to CallBackDialog, ensuring consistent behavior and preventing potential navigation issues.