### PR TITLE
Add reusable statistics block and integrate in hero and split sections

### DIFF
--- a/components/blocks/faqs.tsx
+++ b/components/blocks/faqs.tsx
@@ -19,7 +19,7 @@ export default function FAQs({ padding, colorVariant, faqs }: FAQProps) {
   return (
     <SectionContainer color={color} padding={padding}>
       {faqs && faqs?.length > 0 && (
-        <Accordion className="space-y-4" type="multiple">
+        <Accordion className="max-w-4xl mx-auto space-y-4" type="single">
           {faqs.map((faq) => (
             <AccordionItem key={faq.title} value={`item-${faq._id}`}>
               <AccordionTrigger className="text-xl font-semibold mb-3 cursor-pointer">{faq.title}</AccordionTrigger>

--- a/components/blocks/hero/hero-1.tsx
+++ b/components/blocks/hero/hero-1.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
-import { urlFor } from "@/sanity/lib/image";
-import { stegaClean } from "next-sanity";
+import {urlFor} from "@/sanity/lib/image";
+import {stegaClean} from "next-sanity";
 import PortableTextRenderer from "@/components/portable-text-renderer";
-import { PAGE_QUERYResult } from "@/sanity.types";
+import {PAGE_QUERYResult} from "@/sanity.types";
 import React from "react";
-import { CTAButton } from "@/components/shared/buttons";
+import {CTAButton} from "@/components/shared/buttons";
+import {StatInfoList} from "@/components/shared/info-list";
 
 type Hero1Props = Extract<
     NonNullable<NonNullable<PAGE_QUERYResult>["blocks"]>[number],
@@ -12,47 +13,60 @@ type Hero1Props = Extract<
 >;
 
 export default function Hero1({
-    tagLine,
-    title,
-    body,
-    image,
-    links,
-}: Hero1Props) {
+                                  tagLine,
+                                  title,
+                                  body,
+                                  image,
+                                  links,
+                                  statistics,
+                              }: Hero1Props) {
     return (
         <section className="relative">
-            <div className="container py-20 min-h-[80svh]">
-                <div className="max-w-4xl grid h-full grid-cols-1 gap-10 items-center">
-                    <div className="flex flex-col justify-center items-center md:items-start text-center md:text-left z-10">
-                        {tagLine && (
-                            <span className="backdrop-blur-lg bg-background/30 leading-none animate-fade-up [animation-delay:100ms] opacity-0 border-primary rounded-sm text-pretty text-foreground/70 text-center px-3 py-1 text-sm/6 ring-1 ring-primary/10 hover:ring-primary/20">
+            <div className="container">
+                <div className="">
+                    <div className="max-w-4xl flex flex-col py-20 min-h-[80svh]">
+                        <div
+                            className="flex-1 flex flex-col justify-center md:items-start text-left z-10">
+                            {tagLine && (
+                                <span
+                                    className="self-start backdrop-blur-lg bg-background/30 leading-none animate-fade-up [animation-delay:100ms] opacity-0 border-primary rounded-sm text-pretty text-foreground/70 text-center px-3 py-1 text-sm/6 ring-1 ring-primary/10 hover:ring-primary/20">
                                 {tagLine}
                             </span>
-                        )}
-                        {title && (
-                            <h1 className="mt-6 animate-fade-up [animation-delay:200ms] opacity-0 text-balance leading-none">
-                                {title}
-                            </h1>
-                        )}
-                        {body && (
-                            <article className="text-lg mt-6 animate-fade-up [animation-delay:300ms] opacity-0 text-balance">
-                                <PortableTextRenderer value={body} />
-                            </article>
-                        )}
-                        {links && links.length > 0 && (
-                            <div
-                                className="mt-10 flex flex-wrap gap-2 animate-fade-up [animation-delay:400ms] opacity-0 w-full">
-                                {links.map((link) => (
-                                    <CTAButton
-                                        key={link.title}
-                                        title={link.title}
-                                        href={link.href as string}
-                                        buttonVariant={stegaClean(link?.buttonVariant)}
-                                        target={link.target}
-                                        customGoal="schet1"
-                                    />
-                                ))}
+                            )}
+                            {title && (
+                                <h1 className="mt-6 animate-fade-up [animation-delay:200ms] opacity-0 text-balance leading-none">
+                                    {title}
+                                </h1>
+                            )}
+                            <div className='flex-1'>
+                                {body && (
+                                    <article
+                                        className="text-lg mt-6 animate-fade-up [animation-delay:300ms] opacity-0 text-balance">
+                                        <PortableTextRenderer value={body}/>
+                                    </article>
+                                )}
+                                {links && links.length > 0 && (
+                                    <div
+                                        className="mt-10 flex flex-wrap gap-2 animate-fade-up [animation-delay:400ms] opacity-0 w-full">
+                                        {links.map((link) => (
+                                            <CTAButton
+                                                key={link.title}
+                                                title={link.title}
+                                                href={link.href as string}
+                                                buttonVariant={stegaClean(link?.buttonVariant)}
+                                                target={link.target}
+                                                customGoal="schet1"
+                                            />
+                                        ))}
+                                    </div>
+                                )}
                             </div>
-                        )}
+                            <footer className='mt-10'>
+                                {statistics?.items?.length > 0 && (
+                                    <StatInfoList items={statistics.items}/>
+                                )}
+                            </footer>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/components/blocks/split/split-content.tsx
+++ b/components/blocks/split/split-content.tsx
@@ -6,7 +6,6 @@ import {stegaClean} from "next-sanity";
 import {PAGE_QUERYResult} from "@/sanity.types";
 import {CallBackDialog} from "@/components/shared/dialog";
 import {Card} from "@/components/ui/card";
-import SplitCardsItem from "./split-info-item";
 
 type Block = NonNullable<NonNullable<PAGE_QUERYResult>["blocks"]>[number];
 type SplitRow = Extract<Block, { _type: "split-row" }>;
@@ -17,6 +16,7 @@ type SplitContent = Extract<
 
 interface SplitContentProps extends SplitContent {
     noGap?: boolean;
+    statistics?: {items: {value: string; label: string; highlight?: boolean}[]};
 }
 
 export default function SplitContent({
@@ -63,10 +63,10 @@ export default function SplitContent({
                 </article>
 
                 {infoList?.list && infoList?.list?.length > 0 && (
-                    <div className="flex flex-col gap-6">
-                        <h4 className="font-bold leading-none">Почему молодожёны выбирают подписку</h4>
+                    <div className="flex flex-col gap-8">
+                        <h3 className="font-bold leading-none">Преимущества свадебной цветочной подписки</h3>
                         <div className={cn(
-                            "grid grid-cols-1 gap-2",
+                            "grid md:grid-cols-2 gap-2",
                         )}>
                             {infoList?.list?.map((item, index) => {
                                 return (
@@ -75,7 +75,7 @@ export default function SplitContent({
                                             <i className={cn("text-3xl text-primary", item?.icon)}></i>
                                         </div>
                                         <div className="flex flex-col gap-2">
-                                            <h4 className="text-xl font-semibold leading-none">
+                                            <h4 className="text-xl font-semibold leading-none font-sans">
                                                 {item?.title}
                                             </h4>
                                             {item?.body && <PortableTextRenderer value={item.body}/>}
@@ -87,9 +87,9 @@ export default function SplitContent({
                     </div>
                 )}
 
-                {Array.isArray(statistics) && statistics.length > 0 && (
+                {statistics?.items?.length > 0 && (
                     <ul className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                        {statistics.map(({value, label}) => (
+                        {statistics?.items?.map(({value, label}) => (
                             <li key={label} className="text-center">
                                 <p className="text-3xl font-bold text-primary mb-2">{value}</p>
                                 <p className=" font-normal text-foreground/70">{label}</p>
@@ -99,7 +99,9 @@ export default function SplitContent({
                 )}
 
                 <footer className="flex flex-col">
-                    <Card className='px-4 pt-4'>{footerBody && <PortableTextRenderer value={footerBody}/>}</Card>
+                    {footerBody && (
+                        <Card className='px-4 pt-4'>{footerBody && <PortableTextRenderer value={footerBody}/>}</Card>
+                    )}
 
                     {link?.href && (
                         <div className="flex flex-col self-stretch md:self-start mt-8">

--- a/components/shared/info-list/StatInfoList.tsx
+++ b/components/shared/info-list/StatInfoList.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+export interface StatInfoListProps {
+    items: {value: string; label: string; highlight?: boolean}[];
+}
+
+export default function StatInfoList({items}: StatInfoListProps) {
+    if (!items?.length) return null;
+
+    return (
+        <ul className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {items?.map(({value, label}) => (
+                <li key={label} className="text-center backdrop-blur-lg bg-background/30 rounded-lg shadow-sm p-4 ring-1 ring-primary/10">
+                    <p className="text-3xl font-bold text-primary mb-2">{value}</p>
+                    <p className="font-normal text-foreground/70">{label}</p>
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/components/shared/info-list/index.ts
+++ b/components/shared/info-list/index.ts
@@ -1,0 +1,5 @@
+import StatInfoList from "./StatInfoList";
+
+export {
+    StatInfoList
+}

--- a/sanity/queries/hero/hero-1.ts
+++ b/sanity/queries/hero/hero-1.ts
@@ -42,5 +42,6 @@ export const hero1Query = groq`
       alt
     },
     links,
+    statistics
   }
 `;

--- a/sanity/schema.ts
+++ b/sanity/schema.ts
@@ -1,17 +1,17 @@
-import { type SchemaTypeDefinition } from "sanity";
+import {type SchemaTypeDefinition} from "sanity";
 // documents
 import page from "./schemas/documents/page";
 import post from "./schemas/documents/post";
 import category from "./schemas/documents/category";
 import faq from "./schemas/documents/faq";
 import testimonial from "./schemas/documents/testimonial";
-import userAccount from "./schemas/documents/userAccount"; 
+import userAccount from "./schemas/documents/userAccount";
 
 // shared objects
 import blockContent from "./schemas/blocks/shared/block-content";
 import link from "./schemas/blocks/shared/link";
-import { colorVariant } from "./schemas/blocks/shared/color-variant";
-import { buttonVariant } from "./schemas/blocks/shared/button-variant";
+import {colorVariant} from "./schemas/blocks/shared/color-variant";
+import {buttonVariant} from "./schemas/blocks/shared/button-variant";
 import sectionPadding from "./schemas/blocks/shared/section-padding";
 // objects
 import hero1 from "./schemas/blocks/hero/hero-1";
@@ -38,60 +38,62 @@ import faqs from "./schemas/blocks/faqs";
 import newsletter from "./schemas/blocks/forms/newsletter";
 import allPosts from "./schemas/blocks/all-posts";
 import author from "./schemas/documents/author";
-import { siteSettingsType } from "./schemas/documents/siteSettingsType";
-import { contactInfoType } from "./schemas/blocks/contactInfoType";
+import {siteSettingsType} from "./schemas/documents/siteSettingsType";
+import {contactInfoType} from "./schemas/blocks/contactInfoType";
 import breadcrumbs from "./schemas/blocks/breadcrumbs";
 import registerType from "./schemas/blocks/forms/registerType";
 import productType from "./schemas/documents/productType";
 import gridProduct from "./schemas/blocks/grid/grid-product";
-import { yandexGoal } from "./schemas/blocks/yandexGoalType";
+import {yandexGoal} from "./schemas/blocks/yandexGoalType";
+import statisticsType from "@/sanity/schemas/blocks/shared/statisticsType";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
-  types: [
-    // documents
-    siteSettingsType,
-    page,
-    post,
-    category,
-    author,
-    faq,
-    testimonial,
-    userAccount,
-    productType,
-    // shared objects
-    blockContent,
-    link,
-    colorVariant,
-    buttonVariant,
-    sectionPadding,
-    contactInfoType,
-    // blocks
-    hero1,
-    hero2,
-    sectionHeader,
-    splitRow,
-    splitContent,
-    splitCardsList,
-    splitCard,
-    splitImage,
-    splitInfoList,
-    splitInfo,
-    gridCard,
-    pricingCard,
-    gridPost,
-    gridProduct,
-    gridRow,
-    carousel1,
-    carousel2,
-    timelineRow,
-    timelinesOne,
-    cta1,
-    logoCloud1,
-    faqs,
-    newsletter,
-    registerType,
-    allPosts,
-    breadcrumbs,
-    yandexGoal,
-  ],
+    types: [
+        // documents
+        siteSettingsType,
+        page,
+        post,
+        category,
+        author,
+        faq,
+        testimonial,
+        userAccount,
+        productType,
+        // shared objects
+        blockContent,
+        link,
+        colorVariant,
+        buttonVariant,
+        sectionPadding,
+        contactInfoType,
+        statisticsType,
+        // blocks
+        hero1,
+        hero2,
+        sectionHeader,
+        splitRow,
+        splitContent,
+        splitCardsList,
+        splitCard,
+        splitImage,
+        splitInfoList,
+        splitInfo,
+        gridCard,
+        pricingCard,
+        gridPost,
+        gridProduct,
+        gridRow,
+        carousel1,
+        carousel2,
+        timelineRow,
+        timelinesOne,
+        cta1,
+        logoCloud1,
+        faqs,
+        newsletter,
+        registerType,
+        allPosts,
+        breadcrumbs,
+        yandexGoal,
+    ],
 };

--- a/sanity/schemas/blocks/hero/hero-1.ts
+++ b/sanity/schemas/blocks/hero/hero-1.ts
@@ -53,6 +53,11 @@ export default defineType({
             validation: (rule) => rule.max(2),
             group: "content",
         }),
+        defineField({
+            name: "statistics",
+            type: "statistics",
+            group: "content",
+        }),
     ],
     preview: {
         select: {

--- a/sanity/schemas/blocks/shared/statisticsType.ts
+++ b/sanity/schemas/blocks/shared/statisticsType.ts
@@ -1,0 +1,41 @@
+import {defineField, defineType} from "sanity";
+
+export default defineType({
+    name: "statistics",
+    type: "object",
+    title: "Statistics",
+    description: "Add statistics or key metrics to display",
+    fields: [
+        defineField({
+            name: "items",
+            type: "array",
+            of: [
+                {
+                    type: "object",
+                    fields: [
+                        {
+                            name: "value",
+                            type: "string",
+                            title: "Value",
+                            description: "The numerical value or metric (e.g. '100+' or '2M')"
+                        },
+                        {
+                            name: "label",
+                            type: "string",
+                            title: "Label",
+                            description: "Description of the statistic"
+                        },
+                        {
+                            name: "highlight",
+                            type: "boolean",
+                            title: "Highlight",
+                            description: "Whether to visually emphasize this statistic",
+                            initialValue: false
+                        }
+                    ]
+                }
+            ],
+            validation: Rule => Rule.max(4).warning('Maximum of 4 statistics recommended'),
+        }),
+    ]
+});

--- a/sanity/schemas/blocks/split/split-content.ts
+++ b/sanity/schemas/blocks/split/split-content.ts
@@ -57,36 +57,7 @@ export default defineType({
     }),
     defineField({
       name: "statistics",
-      type: "array",
-      title: "Statistics",
-      description: "Add statistics or key metrics to display",
-      of: [
-        {
-          type: "object",
-          fields: [
-            {
-              name: "value",
-              type: "string",
-              title: "Value",
-              description: "The numerical value or metric (e.g. '100+' or '2M')"
-            },
-            {
-              name: "label",
-              type: "string",
-              title: "Label",
-              description: "Description of the statistic"
-            },
-            {
-              name: "highlight",
-              type: "boolean",
-              title: "Highlight",
-              description: "Whether to visually emphasize this statistic",
-              initialValue: false
-            }
-          ]
-        }
-      ],
-      validation: Rule => Rule.max(4).warning('Maximum of 4 statistics recommended'),
+      type: "statistics",
       group: "infoList",
     }),
     defineField({


### PR DESCRIPTION
Introduced a shared 'statistics' schema and StatInfoList component for displaying key metrics. Updated hero-1 and split-content blocks to use the new statistics object, refactored Sanity schemas to use the shared type, and adjusted queries and UI to support the new structure.