### PR TITLE
style(hero): adjust background opacity for better visibility in light…

### DIFF
--- a/components/blocks/hero/hero-1.tsx
+++ b/components/blocks/hero/hero-1.tsx
@@ -84,7 +84,7 @@ export default function Hero1({
                         />
                     </div>
                 )}
-                <div className="absolute inset-0 bg-background/70" />
+                <div className="absolute inset-0 dark:bg-background/70 bg-background/35" />
             </div>
         </section>
     );


### PR DESCRIPTION
… mode

The background opacity was too strong in light mode, making text hard to read. Reduced opacity from 70% to 35% for light mode while keeping dark mode unchanged.